### PR TITLE
Add Support for Using DRACOLoader via Passing gameOptions.assetOptions.dracoLoaderOptions

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -61,7 +61,7 @@ class Game {
         }
         console.log('Game: reading game.json file to initialize game...');
 
-        this.assetStore = new AssetStore(this.baseURL || this.dirHandle);
+        this.assetStore = new AssetStore(this.baseURL || this.dirHandle, this.gameOptions?.assetOptions);
 
         this.gameJSONAsset = await this.assetStore.load('game.json');
  

--- a/src/assets/Asset.ts
+++ b/src/assets/Asset.ts
@@ -1,6 +1,9 @@
 import EventEmitter from "../util/EventEmitter";
+import AssetStore from "./AssetStore";
 
 class Asset {
+    assetStore: AssetStore;
+
     baseURL: string | null;
     dirHandle: FileSystemDirectoryHandle | null;
 
@@ -11,7 +14,9 @@ class Asset {
 
     eventEmitter: EventEmitter;
 
-    constructor(baseURLorDirHandle: string | FileSystemDirectoryHandle, path: string) {
+    constructor(baseURLorDirHandle: string | FileSystemDirectoryHandle, path: string, assetStore: AssetStore) {
+        this.assetStore = assetStore;
+
         if (typeof baseURLorDirHandle === 'string') {
             this.baseURL = baseURLorDirHandle;
             if (this.baseURL.endsWith('/')) {

--- a/src/assets/AssetStore.ts
+++ b/src/assets/AssetStore.ts
@@ -3,13 +3,15 @@ import TextureAsset from './TextureAsset'
 import SoundAsset from './SoundAsset'
 import JSONAsset from './JSONAsset'
 import Asset from './Asset';
+import { AssetOptions } from '../types';
 
 class AssetStore {
   baseURL: string | null;
   dirHandle: FileSystemDirectoryHandle | null;
   loadedAssets: any;
+  assetOptions: AssetOptions;
 
-  constructor(baseURLorDirHandle: string | FileSystemDirectoryHandle) {
+  constructor(baseURLorDirHandle: string | FileSystemDirectoryHandle, assetOptions: AssetOptions) {
     if (typeof baseURLorDirHandle === 'string') {
       this.baseURL = baseURLorDirHandle;
       if (this.baseURL.endsWith('/')) {
@@ -20,6 +22,8 @@ class AssetStore {
       this.baseURL = null;
       this.dirHandle = baseURLorDirHandle;
     }
+
+    this.assetOptions = assetOptions || {};
 
     this.loadedAssets = {}; // key/value pairs  (url is key, asset is value) all files currently loaded
   }
@@ -50,7 +54,7 @@ class AssetStore {
   async load(path: string): Promise<Asset> {
     if (!this.loadedAssets[path]) {
       const AssetSubclass = AssetStore._getAssetSubclass(path);
-      const asset = new AssetSubclass(this.baseURL || this.dirHandle, path);
+      const asset = new AssetSubclass(this.baseURL || this.dirHandle, path, this);
       await asset.load();
       this.loadedAssets[path] = asset;
       console.log(`AssetStore: successfully loaded asset: ${path}`);

--- a/src/assets/GLTFAsset.ts
+++ b/src/assets/GLTFAsset.ts
@@ -1,12 +1,42 @@
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader';
 
 import Asset from "./Asset";
+import { DracoLoaderOptions } from '../types';
 
 class GLTFAsset extends Asset {
+    // As recommended by Three.js it's recommended to create one
+    // instance of DracoLoader and re-use it. 
+    static _dracoLoader;
+
+    static getDracoLoader(options: DracoLoaderOptions) {
+        if (!GLTFAsset._dracoLoader) {
+            const loader = new DRACOLoader();
+            loader.setDecoderPath(options.path);
+            if ('decoderConfig' in options) {
+                loader.setDecoderConfig(options.decoderConfig);
+            }
+            if ('workerLimit' in options) {
+                loader.setWorkerLimit(options.workerLimit);
+            }
+
+            GLTFAsset._dracoLoader = loader;
+        }
+        return GLTFAsset._dracoLoader;
+    }
 
     async load() : Promise<void> {
         return new Promise((resolve, reject) => {
             const loader = new GLTFLoader();
+
+            // Optional: GLTFLoader can use a DRACOLoader instance to decode any 
+            // Draco compressed mesh data inside the GTLF/GLB file.
+            const { dracoLoaderOptions } = this.assetStore.assetOptions;
+            if (dracoLoaderOptions) {
+                const dracoLoader = GLTFAsset.getDracoLoader(dracoLoaderOptions);
+                loader.setDRACOLoader(dracoLoader);
+            }
+
             this.getFullURL().then(fullURL => {
                 loader.load(fullURL,
                     data => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -73,6 +73,13 @@ interface CameraOptions {
 
 interface AssetOptions {
     baseURL?: string;
+    dracoLoaderOptions?: DracoLoaderOptions;
+}
+
+interface DracoLoaderOptions {
+    path: string;
+    decoderConfig: Object;
+    workerLimit?: number;
 }
 
 interface InputOptions {


### PR DESCRIPTION
This feature can be used by passing config to the Game class constructor like:

```
const game = new Game(baseURL, {
  ...
  assetOptions: {
    dracoLoaderOptions: {
      path: 'https://www.gstatic.com/draco/v1/decoders/',
      decoderConfig: {
        type: 'js'
      },
      workerLimit: 1
    }
  }
});
```

This will create a DRACOLoader instance, attach it to the GLTFLoader used to load GTLF/GLB assets, and will offer support for GLTF/GLB files that internally use Draco compression for mesh data.